### PR TITLE
Add types before brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Examples
 
     $q->table('table')
     ->begin_and()
-    ->begin_and()
+    ->begin_and(false)      // false so we don't add and before opening bracket
     ->and_where('col_1', 1)
     ->or_where('col_2', 2)
     ->end_and()

--- a/source/query.class.php
+++ b/source/query.class.php
@@ -264,22 +264,26 @@ class query{
 	}
 	/**
 	 * Push an open bracket into the where stack to group OR conditions
+	 * @param bool $add_type_before
 	 * @return query
 	 */
-	public function begin_or(){
+	public function begin_or($add_type_before = true){
 		$this->wheres[] = array(
 			'bracket'=>'OPEN',
+			'add_type_before'=>$add_type_before,
 			'type'=>'OR'
 		);
 		return $this;
 	}
 	/**
 	 * Push an open bracket into the where stack to group AND conditions
+	 * @param bool $add_type_before
 	 * @return query
 	 */
-	public function begin_and(){
+	public function begin_and($add_type_before = true){
 		$this->wheres[] = array(
 			'bracket'=>'OPEN',
+			'add_type_before'=>$add_type_before,
 			'type'=>'AND'
 		);
 		return $this;
@@ -620,7 +624,10 @@ class query{
 			}
 			if(isset($w['bracket'])){
 				if($w['bracket'] === 'OPEN'){
-					$string .= '( ';
+					if($w['add_type_before'] && !$first){
+						$string .= ' ' . $w['type'] . ' ';
+					}
+					$string .= ' ( ';
 					$bracket = true;
 				} else {
 					$string .= ' )';


### PR DESCRIPTION
adding more begin_or/begin_and wont add AND/OR before brackets, hence breaks the query.
these changes now by default it would add AND/OR.
you can specify false to not add forcefully.